### PR TITLE
Clarify application is for Windows only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <img alt="Logo" height="50" src="https://raw.githubusercontent.com/grocy/grocy/master/public/img/logo.svg?sanitize=true" />
 <h3>Grocy Desktop</h3>
-<h4>A (Windows) desktop application wrapper for <a href="https://github.com/grocy/grocy">Grocy</a><br>Created by <a href="https://github.com/berrnd">@berrnd</a></h4>
+<h4>A Windows(-only) desktop application wrapper for <a href="https://github.com/grocy/grocy">Grocy</a><br>Created by <a href="https://github.com/berrnd">@berrnd</a></h4>
 </div>
 
 -----


### PR DESCRIPTION
As confusion rose in https://github.com/grocy/grocy-desktop/issues/49. I may have overread that, but it is also somewhat ambiguous.

> A (Windows) desktop application

means:

> A Windows desktop application

and/or

> A desktop application

This could e.g. mean the application is not yet ready for macOS or Linux and may need work. (And Windows is just the current compatibility.) Like "A desktop application (currently only for Windows)".
Or, as in this case, it is Windows only. I just would not put Windows in brackets then, as it actually is a "Windows desktop application" then. Alternatively "A desktop application (only for Windows)".

We could even replace it with the specific framework or so if we want to be more clear.