### PR TITLE
Added the possibility to use data in "portable" mode.

### DIFF
--- a/grocy-desktop/Program.cs
+++ b/grocy-desktop/Program.cs
@@ -15,6 +15,22 @@ namespace GrocyDesktop
 		internal static readonly string RunningVersion = Regex.Replace(Assembly.GetExecutingAssembly().GetName().Version.ToString(), @"^(.+?)(\.0+)$", "$1");
 		internal static readonly string BaseExecutingPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location.TrimEnd('\\'));
 		internal static readonly string PortableFilePath = Path.Combine(BaseExecutingPath, "portable");
+		static bool IsValidPath(string path)
+		{
+			if (!Path.IsPathRooted(path))
+			{
+				return false;
+			}
+
+			char[] invalidPathChars = Path.GetInvalidPathChars();
+			if (path.Any(c => invalidPathChars.Contains(c)))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
 
 		internal static string BaseFixedUserDataFolderPath
 		{
@@ -30,15 +46,17 @@ namespace GrocyDesktop
 					{
 						try
 						{
-							string firstLine = File.ReadLines(PortableFilePath).First();
-							if (firstLine != null)
+							string PortableSettingsPath = File.ReadLines(PortableFilePath).First();
+							if (PortableSettingsPath != null && IsValidPath(PortableSettingsPath))
 							{
-								return firstLine;
+								return PortableSettingsPath;
 							}
+							else
+								return Path.Combine(BaseExecutingPath, "grocy-desktop");
 						}
 						catch (Exception ex)
 						{
-							return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "grocy-desktop");
+							return Path.Combine(BaseExecutingPath, "grocy-desktop");
 						}
 					}
 

--- a/grocy-desktop/Program.cs
+++ b/grocy-desktop/Program.cs
@@ -2,6 +2,7 @@ using GrocyDesktop.Helpers;
 using GrocyDesktop.Management;
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -13,6 +14,7 @@ namespace GrocyDesktop
 	{
 		internal static readonly string RunningVersion = Regex.Replace(Assembly.GetExecutingAssembly().GetName().Version.ToString(), @"^(.+?)(\.0+)$", "$1");
 		internal static readonly string BaseExecutingPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location.TrimEnd('\\'));
+		internal static readonly string PortableFilePath = Path.Combine(BaseExecutingPath, "portable");
 
 		internal static string BaseFixedUserDataFolderPath
 		{
@@ -24,6 +26,22 @@ namespace GrocyDesktop
 				}
 				else
 				{
+					if (File.Exists(PortableFilePath))
+					{
+						try
+						{
+							string firstLine = File.ReadLines(PortableFilePath).First();
+							if (firstLine != null)
+							{
+								return firstLine;
+							}
+						}
+						catch (Exception ex)
+						{
+							return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "grocy-desktop");
+						}
+					}
+
 					return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "grocy-desktop");
 				}
 			}


### PR DESCRIPTION
Added the possibility to use data in "portable" mode where the path to the data is specified in a file named portable. Not for UWP. The portable file must be next to the exe and in the first line contain the path to the directory to be used instead of %AppData%/grocy-desktop.

Please tell me what you think. I did it for myself, but maybe you will find it useful.